### PR TITLE
MIA module and DUCI module added

### DIFF
--- a/module_duci.py
+++ b/module_duci.py
@@ -1,33 +1,39 @@
+from typing import Tuple, List, Any
 import numpy as np
 from sklearn.metrics import roc_curve
 import logging
-from attacks import tune_offline_a, run_rmia, run_loss
 import time
 
-logger = logging.getLogger(__name__)
+import modules.mia
 
 class DUCI:
-    def __init__(self, num_reference_models):
+    def __init__(self, logger: logging.Logger):
         """
         Initialize the DUCI object.
 
         Args:
-            num_reference_models (int): Number of reference models to use.
-            offline_a (float): The offline adjustment parameter.
+            num_reference_models (int): Number of reference models to use. 
+                In DUCI, the real num_reference_models is the number of reference models used. 
+                However, in this implementation, we follow the setting of MIA, i.e., for each
+                sample, num_reference_models reference model is used. Therefore, whne the models are trained
+                with half-half split, the num_reference_models is set to half of the number of reference models.
         """
-        self.num_reference_models = num_reference_models
-        self.offline_a = None
         self.best_threshold = None
         self.tpr = None
         self.fpr = None
+        self.logger = logger
 
-    def pred_proportion(self, target_model_indices, mia_score_list, membership_list, offline_a):
+    def debias_pred(self, 
+            target_model_idx: int,
+            reference_model_indices: np.ndarray,
+            all_signals: np.ndarray,
+            all_memberships: np.ndarray,
+        ) -> Tuple[float, float]:
         """
-        This functions takes in the MIA signals of the target dataset on the target model, 
-        the MIA signals and membership flags over the dataset of reference models to 
-        debias the MIA signals received on the target model. Then, by aggregating the
-        debiased signals, we can make an unbiased prediction to the proportion of dataset 
-        being used in the target model.
+        This functions debiases the MIA signals over the target dataset received on the target model 
+        through reusing the MIA signals and membership flags over the dataset of reference models. Then, 
+        by aggregating the debiased signals, we can make an unbiased prediction to the proportion of 
+        dataset being used in the target model.
 
         The proportion (\hat{p}) is computed as the aggregation of individual estimates (\hat{p}_i) 
         over all data points in the target dataset (X):
@@ -47,134 +53,112 @@ class DUCI:
 
         Args:
             target_model_idx (int): Index of the target model.
-            mia_score_list (np.ndarray): List of signal matrix with shape (samples, models).
-            membership_list (np.ndarray): List of membership matrix with shape (samples, models).
+            mia_scores (np.ndarray): MIA scores for the target model.
+            all_signals (np.ndarray): List of signal matrix with shape (samples, models).
+            all_memberships (np.ndarray): List of membership matrix with shape (samples, models).
 
         Returns:
             dict: A dictionary containing debiased predictions, TPR, FPR, and absolute errors.
         """
-        self.offline_a = offline_a
-        pre_debias_errors, post_debias_errors = [], []
-        for idx, target_model_idx in enumerate(target_model_indices):
-            all_signals = mia_score_list[idx]
-            all_memberships = membership_list[idx]
-            # Identify paired model and reference indices
-            paired_model_idx = target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
-            columns = [
-                i for i in range(all_signals.shape[1])
-                if i != target_model_idx and i != paired_model_idx
-            ][:2 * self.num_reference_models]
+        # Conduct MIA on the target model using privacy meter tools
+        baseline_time = time.time()
+        args = {
+            "attack": "RMIA",
+            "offline_a": None
+        }
+        mia_scores, target_memberships = modules.mia(
+            all_signals, 
+            all_memberships, 
+            target_model_idx, 
+            reference_model_indices, 
+            self.logger, 
+            args
+        )
+        self.logger.info("Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+            target_model_idx, time.time() - baseline_time,
+        )
 
-            # Select and process reference signals
-            selected_signals = all_signals[:, columns]
-            non_members = ~all_memberships[:, columns]
-            out_signals = selected_signals * non_members
-            out_signals = -np.sort(-out_signals, axis=1)[:, :self.num_reference_models]
-
-            # Compute mean values
-            mean_out_x = np.mean(out_signals, axis=1)
-            mean_x = (1 + self.offline_a) / 2 * mean_out_x + (1 - self.offline_a) / 2
-
-            # De-bias using paired model
-            ref_target_signals = all_signals[:, paired_model_idx]
-            mia_scores_for_debiasing = ref_target_signals / mean_x
-
-            debias_scores = np.array(mia_scores_for_debiasing)
-            debias_memberships = all_memberships[:, paired_model_idx]
-
-            # Find the optimal threshold
-            fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
-            self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
-            self.tpr = np.max(tpr_list)
-            self.fpr = np.min(fpr_list)
-
-            logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
-
-            # Apply threshold to target model scores
-            preds = (all_signals[:, target_model_idx] > self.best_threshold).ravel()
-            target_memberships = all_memberships[:, target_model_idx]
-
-            true_tpr = np.sum(preds * target_memberships.ravel()) / np.sum(target_memberships.ravel())
-            true_fpr = np.sum(preds * ~target_memberships.ravel()) / np.sum(~target_memberships.ravel())
-
-            logger.info(f"Direct aggregation of MIA preds: {np.mean(preds)}, TPR: {true_tpr}, FPR: {true_fpr}")
-
-            # Compute debiased predictions
-            debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
-            true_proportion = np.mean(target_memberships)
-            logger.info(f"Debiased aggregation of MIA preds: {np.mean(debiased_pres)}")
-            pre_debias_error = np.abs(np.mean(preds) - true_proportion)
-            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
-            logger.info(
-                r"Absolute Error $| \hat{p} - p|$: Agg MIA = %.4f, Debiased Agg MIA = %.4f",
-                pre_debias_error,
-                post_debias_error
+        # Conduct MIA on the reference model using privacy meter tools
+        ref_score_all, ref_membership_all = [], []
+        for ref_model_idx in reference_model_indices:
+            ref_mia_scores, ref_target_memberships = modules.mia(
+                all_signals,
+                all_memberships,
+                ref_model_idx,
+                reference_model_indices,
+                self.logger,
+                args
             )
-            pre_debias_errors.append(pre_debias_error)
-            post_debias_errors.append(post_debias_error)
+            ref_score_all.append(ref_mia_scores)
+            ref_membership_all.append(ref_target_memberships)
+        debias_memberships = np.array(ref_membership_all)
+        debias_scores = np.array(ref_score_all)
 
-        return pre_debias_errors, post_debias_errors
-    
-    def get_ind_signals(
+        # Find the optimal threshold
+        fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
+        self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
+        self.tpr = np.max(tpr_list)
+        self.fpr = np.min(fpr_list)
+
+        self.logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
+
+        # Apply threshold to target model scores
+        preds = mia_scores > self.best_threshold
+
+        true_tpr = np.sum(preds * target_memberships) / np.sum(target_memberships)
+        true_fpr = np.sum(preds * ~target_memberships) / np.sum(~target_memberships)
+        true_proportion = np.mean(target_memberships)
+        self.logger.info(f"True proportion {true_proportion}, True TPR: {true_tpr}, True FPR: {true_fpr}")
+
+        # Compute debiased predictions
+        debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
+        self.logger.info(f"DUCI prediction: {np.mean(debiased_pres)}; Direct Aggregation: {np.mean(preds)}")
+
+        return debiased_pres, true_proportion
+
+    def pred_proportions(
         self, 
-        target_model_indices,
-        all_signals,
-        all_memberships,
-        num_reference_models,
-        logger,
-        configs,
-    ):
+        target_model_indices: List[int],
+        reference_model_indices_all: List[np.ndarray],
+        all_signals: np.ndarray,
+        all_memberships: np.ndarray,
+    ) -> Tuple[List[float], List[float], List[float]]:
         """
-        Launch Membership Inference Attacks for each samples in the target dataset on target models using Privacy Meter tool.
+        Launch Membership Inference Attacks on target dataset over ALL target models using Privacy Meter tool.
 
         Args:
             target_model_indices (list): List of the target model indices.
-            all_signals (np.array): Signal value of all samples in all models (target and reference models).
-            all_memberships (np.array): Membership matrix for all models.
-            num_reference_models (int): Number of reference models used for performing the attack.
-            logger (logging.Logger): Logger object for the current run.
-            configs (dict): Configs provided by the user.
-
+            reference_model_indices (list): List of the reference model indices array.
+            all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+            all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+        
         Returns:
-            list: List of MIA score arrays for all audited target models.
-            list: List of membership labels for all target models.
+            Tuple[List[float], List[float], List[float]]: A tuple containing debiased predictions, true proportions, and errors.
         """
-        all_memberships = np.transpose(all_memberships)
+        assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
 
-        mia_score_list = []
-        membership_list = []
-
-        for target_model_idx in target_model_indices:
-            baseline_time = time.time()
-            # TODO: call the MIA module
-            if configs["audit"]["algorithm"] == "RMIA":
-                offline_a = tune_offline_a(
-                    target_model_idx, all_signals, all_memberships, logger
-                )
-                logger.info(f"The best offline_a is %0.1f", offline_a)
-                mia_scores = run_rmia(
-                    target_model_idx,
-                    all_signals,
-                    all_memberships,
-                    num_reference_models,
-                    offline_a,
-                )
-            #TODO: remove the loss
-            elif configs["audit"]["algorithm"] == "LOSS":
-                mia_scores = run_loss(all_signals[:, target_model_idx])
-            else:
-                raise NotImplementedError(
-                    f"{configs['audit']['algorithm']} is not implemented"
-                )
-
-            target_memberships = all_memberships[:, target_model_idx]
-
-            mia_score_list.append(mia_scores.copy())
-            membership_list.append(target_memberships.copy())
-
-            logger.info(
-                "Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+        debiased_preds_list, true_proportion_list = [], []
+        error_list = []
+        # for target_model_idx in target_model_indices:
+        for target_model_idx, reference_model_indices in zip(target_model_indices, reference_model_indices_all):
+            debiased_pres, true_proportion = self.debias_pred(
                 target_model_idx,
-                time.time() - baseline_time,
+                reference_model_indices,
+                all_signals,
+                all_memberships,
             )
-        return mia_score_list, membership_list, offline_a
+
+            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
+            self.logger.info(
+                r"Absolute Error $| \hat{p} - p|$: Debiased Agg MIA = %.4f",
+                post_debias_error
+            )
+
+            debiased_preds_list.append(debiased_pres)
+            true_proportion_list.append(true_proportion)
+            error_list.append(post_debias_error)
+
+        return debiased_preds_list, true_proportion_list, error_list
+    
+    def eval():
+        pass

--- a/module_duci.py
+++ b/module_duci.py
@@ -1,0 +1,180 @@
+import numpy as np
+from sklearn.metrics import roc_curve
+import logging
+from attacks import tune_offline_a, run_rmia, run_loss
+import time
+
+logger = logging.getLogger(__name__)
+
+class DUCI:
+    def __init__(self, num_reference_models):
+        """
+        Initialize the DUCI object.
+
+        Args:
+            num_reference_models (int): Number of reference models to use.
+            offline_a (float): The offline adjustment parameter.
+        """
+        self.num_reference_models = num_reference_models
+        self.offline_a = None
+        self.best_threshold = None
+        self.tpr = None
+        self.fpr = None
+
+    def pred_proportion(self, target_model_indices, mia_score_list, membership_list, offline_a):
+        """
+        This functions takes in the MIA signals of the target dataset on the target model, 
+        the MIA signals and membership flags over the dataset of reference models to 
+        debias the MIA signals received on the target model. Then, by aggregating the
+        debiased signals, we can make an unbiased prediction to the proportion of dataset 
+        being used in the target model.
+
+        The proportion (\hat{p}) is computed as the aggregation of individual estimates (\hat{p}_i) 
+        over all data points in the target dataset (X):
+        
+            \hat{p} = (1 / |X|) * sum_{i=1}^{|X|}(\hat{p}_i)
+
+        Each individual estimate (\hat{p}_i) is calculated as:
+
+            \hat{p}_i = (\hat{m}_i - P(\hat{m}_i = 1 | m_i = 0)) / 
+                        (P(\hat{m}_i = 1 | m_i = 1) - P(\hat{m}_i = 1 | m_i = 0))
+        
+        where:
+            - \hat{m}_i: MIA signal for the i-th data point in the target dataset.
+            - P(\hat{m}_i = 1 | m_i = 0): False positive rate (FPR) derived from reference models.
+            - P(\hat{m}_i = 1 | m_i = 1): True positive rate (TPR) derived from reference models.
+            
+
+        Args:
+            target_model_idx (int): Index of the target model.
+            mia_score_list (np.ndarray): List of signal matrix with shape (samples, models).
+            membership_list (np.ndarray): List of membership matrix with shape (samples, models).
+
+        Returns:
+            dict: A dictionary containing debiased predictions, TPR, FPR, and absolute errors.
+        """
+        self.offline_a = offline_a
+        pre_debias_errors, post_debias_errors = [], []
+        for idx, target_model_idx in enumerate(target_model_indices):
+            all_signals = mia_score_list[idx]
+            all_memberships = membership_list[idx]
+            # Identify paired model and reference indices
+            paired_model_idx = target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+            columns = [
+                i for i in range(all_signals.shape[1])
+                if i != target_model_idx and i != paired_model_idx
+            ][:2 * self.num_reference_models]
+
+            # Select and process reference signals
+            selected_signals = all_signals[:, columns]
+            non_members = ~all_memberships[:, columns]
+            out_signals = selected_signals * non_members
+            out_signals = -np.sort(-out_signals, axis=1)[:, :self.num_reference_models]
+
+            # Compute mean values
+            mean_out_x = np.mean(out_signals, axis=1)
+            mean_x = (1 + self.offline_a) / 2 * mean_out_x + (1 - self.offline_a) / 2
+
+            # De-bias using paired model
+            ref_target_signals = all_signals[:, paired_model_idx]
+            mia_scores_for_debiasing = ref_target_signals / mean_x
+
+            debias_scores = np.array(mia_scores_for_debiasing)
+            debias_memberships = all_memberships[:, paired_model_idx]
+
+            # Find the optimal threshold
+            fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
+            self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
+            self.tpr = np.max(tpr_list)
+            self.fpr = np.min(fpr_list)
+
+            logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
+
+            # Apply threshold to target model scores
+            preds = (all_signals[:, target_model_idx] > self.best_threshold).ravel()
+            target_memberships = all_memberships[:, target_model_idx]
+
+            true_tpr = np.sum(preds * target_memberships.ravel()) / np.sum(target_memberships.ravel())
+            true_fpr = np.sum(preds * ~target_memberships.ravel()) / np.sum(~target_memberships.ravel())
+
+            logger.info(f"Direct aggregation of MIA preds: {np.mean(preds)}, TPR: {true_tpr}, FPR: {true_fpr}")
+
+            # Compute debiased predictions
+            debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
+            true_proportion = np.mean(target_memberships)
+            logger.info(f"Debiased aggregation of MIA preds: {np.mean(debiased_pres)}")
+            pre_debias_error = np.abs(np.mean(preds) - true_proportion)
+            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
+            logger.info(
+                r"Absolute Error $| \hat{p} - p|$: Agg MIA = %.4f, Debiased Agg MIA = %.4f",
+                pre_debias_error,
+                post_debias_error
+            )
+            pre_debias_errors.append(pre_debias_error)
+            post_debias_errors.append(post_debias_error)
+
+        return pre_debias_errors, post_debias_errors
+    
+    def get_ind_signals(
+        self, 
+        target_model_indices,
+        all_signals,
+        all_memberships,
+        num_reference_models,
+        logger,
+        configs,
+    ):
+        """
+        Launch Membership Inference Attacks for each samples in the target dataset on target models using Privacy Meter tool.
+
+        Args:
+            target_model_indices (list): List of the target model indices.
+            all_signals (np.array): Signal value of all samples in all models (target and reference models).
+            all_memberships (np.array): Membership matrix for all models.
+            num_reference_models (int): Number of reference models used for performing the attack.
+            logger (logging.Logger): Logger object for the current run.
+            configs (dict): Configs provided by the user.
+
+        Returns:
+            list: List of MIA score arrays for all audited target models.
+            list: List of membership labels for all target models.
+        """
+        all_memberships = np.transpose(all_memberships)
+
+        mia_score_list = []
+        membership_list = []
+
+        for target_model_idx in target_model_indices:
+            baseline_time = time.time()
+            # TODO: call the MIA module
+            if configs["audit"]["algorithm"] == "RMIA":
+                offline_a = tune_offline_a(
+                    target_model_idx, all_signals, all_memberships, logger
+                )
+                logger.info(f"The best offline_a is %0.1f", offline_a)
+                mia_scores = run_rmia(
+                    target_model_idx,
+                    all_signals,
+                    all_memberships,
+                    num_reference_models,
+                    offline_a,
+                )
+            #TODO: remove the loss
+            elif configs["audit"]["algorithm"] == "LOSS":
+                mia_scores = run_loss(all_signals[:, target_model_idx])
+            else:
+                raise NotImplementedError(
+                    f"{configs['audit']['algorithm']} is not implemented"
+                )
+
+            target_memberships = all_memberships[:, target_model_idx]
+
+            mia_score_list.append(mia_scores.copy())
+            membership_list.append(target_memberships.copy())
+
+            logger.info(
+                "Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+                target_model_idx,
+                time.time() - baseline_time,
+            )
+        return mia_score_list, membership_list, offline_a

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,0 @@
-from .mia import run_mia as mia

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+from .mia import run_mia as mia

--- a/modules/mia/__init__.py
+++ b/modules/mia/__init__.py
@@ -1,1 +1,1 @@
-from .attack import run_mia
+from .attack import MIA

--- a/modules/mia/__init__.py
+++ b/modules/mia/__init__.py
@@ -1,0 +1,1 @@
+from .attack import run_mia

--- a/modules/mia/attack.py
+++ b/modules/mia/attack.py
@@ -1,48 +1,85 @@
-from typing import Any, Tuple, Dict
+from typing import Any, Tuple, Dict, Optional
 import logging
 import numpy as np
 from .attacks import run_rmia, tune_offline_a
 
-def run_mia(
-    all_signals: np.ndarray,
-    all_memberships: np.ndarray,
-    target_model_idx: int,
-    reference_model_indices: np.ndarray,
-    logger: logging.Logger,
-    args: Dict[str, Any],
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Launch a membership inference attack on a target model and output the MIA scores.
-    
-    Args:
-        all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
-        all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
-        target_model_idx (int): Index of the target model.
-        reference_model_indices (np.ndarray): List of indices of reference models.
-        args (Dict[str, Any]): Arguments for the MIA attack.
+class MIA:
+    def __init__(self, logger: logging.Logger):
+        """
+        Initialize the MIA object with configuration storage and a logger.
 
-    Returns:
-        Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
-    """
-    assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
-    target_signals = all_signals[:, target_model_idx]
-    target_memberships = all_memberships[:, target_model_idx]
-
-    ref_signals = all_signals[:, reference_model_indices]
-    ref_memberships = all_memberships[:, reference_model_indices]
+        Args:
+            args (Dict[str, Any]): Configuration storage for existing MIA attacks to avoid retuning.
+            logger (logging.Logger): Logger instance for logging information.
+        """
+        self.configs: Dict[frozenset, Dict[str, Any]] = {}
+        self.logger = logger
     
-    logger.info(f"Args for MIA attack: {args}")
-    if args["attack"] == "RMIA":
-        if args.get("offline_a") is None:
-            offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
-            # offline_a = args.get("offline_a", 0.3)
+    def _serialize_args(self, args: Dict[str, Any]) -> frozenset:
+        """
+        Serialize the args dictionary into a frozenset to use as a hashable key.
+
+        Args:
+            args (Dict[str, Any]): The configuration arguments.
+
+        Returns:
+            frozenset: A hashable representation of the args.
+        """
+        keys_to_extract = ["attack", "dataset", "model"]  # Keys to include in the frozenset
+        extracted_items = [(key, args[key]) for key in keys_to_extract if key in args]
+        return frozenset(extracted_items)
+    
+    def run_mia(
+        self,
+        all_signals: np.ndarray,
+        all_memberships: np.ndarray,
+        target_model_idx: int,
+        reference_model_indices: np.ndarray,
+        logger: logging.Logger,
+        args: Dict[str, Any],
+        reuse_offline_a: Optional[bool] = False,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Launch a membership inference attack on a target model and output the MIA scores.
         
-        logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
-        mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
-    else:
-        raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
-    
-    return mia_scores, target_memberships
+        Args:
+            all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+            all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+            target_model_idx (int): Index of the target model.
+            reference_model_indices (np.ndarray): List of indices of reference models.
+            args (Dict[str, Any]): Arguments for the MIA attack.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
+        """
+        assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
+        target_signals = all_signals[:, target_model_idx]
+        target_memberships = all_memberships[:, target_model_idx]
+
+        ref_signals = all_signals[:, reference_model_indices]
+        ref_memberships = all_memberships[:, reference_model_indices]
+        
+        logger.info(f"Args for MIA attack: {args}")
+        if args["attack"] == "RMIA":
+            if args.get("offline_a") is None:
+                serialized_key = self._serialize_args(args)
+                # Reuse the offline_a if it has been computed before for the same dataset and architecture
+                if reuse_offline_a and serialized_key in self.configs:
+                    offline_a = self.configs[serialized_key]["offline_a"]
+                    logger.info(f"Using cached offline_a={offline_a}")
+                else:
+                    offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
+                    # offline_a = args.get("offline_a", 0.3)
+                    args["offline_a"] = offline_a
+                    self.configs[serialized_key] = args
+            else:
+                offline_a = args["offline_a"]
+            logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
+            mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
+        else:
+            raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
+        
+        return mia_scores, target_memberships
 
   
 

--- a/modules/mia/attack.py
+++ b/modules/mia/attack.py
@@ -1,0 +1,52 @@
+from typing import Any, Tuple, Dict
+import logging
+import numpy as np
+from .attacks import run_rmia, tune_offline_a
+
+def run_mia(
+    all_signals: np.ndarray,
+    all_memberships: np.ndarray,
+    target_model_idx: int,
+    reference_model_indices: np.ndarray,
+    logger: logging.Logger,
+    args: Dict[str, Any],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Launch a membership inference attack on a target model and output the MIA scores.
+    
+    Args:
+        all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+        all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+        target_model_idx (int): Index of the target model.
+        reference_model_indices (np.ndarray): List of indices of reference models.
+        args (Dict[str, Any]): Arguments for the MIA attack.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
+    """
+    assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
+    target_signals = all_signals[:, target_model_idx]
+    target_memberships = all_memberships[:, target_model_idx]
+
+    ref_signals = all_signals[:, reference_model_indices]
+    ref_memberships = all_memberships[:, reference_model_indices]
+    
+    logger.info(f"Args for MIA attack: {args}")
+    if args["attack"] == "RMIA":
+        if args.get("offline_a") is None:
+            offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
+            # offline_a = args.get("offline_a", 0.3)
+        
+        logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
+        mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
+    else:
+        raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
+    
+    return mia_scores, target_memberships
+
+  
+
+
+
+
+

--- a/modules/mia/attacks/__init__.py
+++ b/modules/mia/attacks/__init__.py
@@ -1,0 +1,1 @@
+from .rmia import run_rmia, tune_offline_a

--- a/modules/mia/attacks/loss.py
+++ b/modules/mia/attacks/loss.py
@@ -1,0 +1,14 @@
+# import numpy as np
+
+# def run_loss(target_signals: np.ndarray) -> np.ndarray:
+#     """
+#     Attack a target model using the LOSS attack.
+
+#     Args:
+#         target_signals (np.ndarray): Softmax value of all samples in the target model.
+
+#     Returns:
+#         np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+#     """
+#     mia_scores = -target_signals
+#     return mia_scores

--- a/modules/mia/attacks/rmia.py
+++ b/modules/mia/attacks/rmia.py
@@ -1,0 +1,208 @@
+from typing import Any, Optional
+from sklearn.metrics import auc, roc_curve
+import numpy as np
+
+# def get_rmia_out_signals(
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     target_model_idx: int,
+#     num_reference_models: int,
+# ) -> np.ndarray:
+#     """
+#     Get average prediction probability of samples over offline reference models (excluding the target model).
+
+#     Args:
+#         all_signals (np.ndarray): Softmax value of all samples in every model.
+#         all_memberships (np.ndarray): Membership matrix for all models (if a sample is used for training a model).
+#         target_model_idx (int): Target model index.
+#         num_reference_models (int): Number of reference models used for the attack.
+
+#     Returns:
+#         np.ndarray: Average softmax value for each sample over OUT reference models.
+#     """
+#     paired_model_idx = (
+#         target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+#     )
+#     # Add non-target and non-paired model indices
+#     columns = [
+#         i
+#         for i in range(all_signals.shape[1])
+#         if i != target_model_idx and i != paired_model_idx
+#     ][: 2 * num_reference_models]
+#     selected_signals = all_signals[:, columns]
+#     non_members = ~all_memberships[:, columns]
+#     out_signals = selected_signals * non_members
+#     # Sort the signals such that only the non-zero signals (out signals) are kept
+#     out_signals = -np.sort(-out_signals, axis=1)[:, :num_reference_models]
+#     return out_signals
+
+
+# def tune_offline_a(
+#     target_model_idx: int,
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     logger: Any,
+# ) -> float:
+#     """
+#     Fine-tune coefficient offline_a used in RMIA.
+
+#     Args:
+#         target_model_idx (int): Index of the target model.
+#         all_signals (np.ndarray): Softmax value of all samples in two models (target and reference).
+#         all_memberships (np.ndarray): Membership matrix for all models.
+#         logger (Any): Logger object for the current run.
+
+#     Returns:
+#         float: Optimized offline_a obtained by attacking a paired model with the help of the reference models.
+#     """
+#     paired_model_idx = (
+#         target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+#     )
+#     logger.info(f"Fine-tuning offline_a using paired model {paired_model_idx}")
+#     paired_memberships = all_memberships[:, paired_model_idx]
+#     offline_a = 0.0
+#     max_auc = 0
+#     for test_a in np.arange(0, 1.1, 0.1):
+#         mia_scores = run_rmia(paired_model_idx, all_signals, all_memberships, 1, test_a)
+#         fpr_list, tpr_list, _ = roc_curve(
+#             paired_memberships.ravel(), mia_scores.ravel()
+#         )
+#         roc_auc = auc(fpr_list, tpr_list)
+#         if roc_auc > max_auc:
+#             max_auc = roc_auc
+#             offline_a = test_a
+#             mia_scores_array = mia_scores.ravel().copy()
+#             membership_array = paired_memberships.ravel().copy()
+#         logger.info(f"offline_a={test_a:.2f}: AUC {roc_auc:.4f}")
+#     return offline_a, mia_scores_array, membership_array
+
+
+# def run_rmia(
+#     target_model_idx: int,
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     num_reference_models: int,
+#     offline_a: float,
+# ) -> np.ndarray:
+#     """
+#     Attack a target model using the RMIA attack with the help of offline reference models.
+
+#     Args:
+#         target_model_idx (int): Index of the target model.
+#         all_signals (np.ndarray): Softmax value of all samples in the target model.
+#         all_memberships (np.ndarray): Membership matrix for all models.
+#         num_reference_models (int): Number of reference models used for the attack.
+#         offline_a (float): Coefficient offline_a is used to approximate p(x) using P_out in the offline setting.
+
+#     Returns:
+#         np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+#     """
+#     target_signals = all_signals[:, target_model_idx]
+#     out_signals = get_rmia_out_signals(
+#         all_signals, all_memberships, target_model_idx, num_reference_models
+#     )
+#     mean_out_x = np.mean(out_signals, axis=1)
+#     mean_x = (1 + offline_a) / 2 * mean_out_x + (1 - offline_a) / 2
+#     prob_ratio_x = target_signals.ravel() / mean_x
+
+#     return prob_ratio_x
+
+def get_out_ref_signals(
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    num_reference_models: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Get average prediction probability of samples over offline reference models (excluding the target model).
+
+    Args:
+        ref_signals (np.ndarray): Softmax value of all samples in all reference model.  Shape: (num_samples * num_models)
+        ref_memberships (np.ndarray): Membership matrix for all reference models (if a sample is used for training a model).  Shape: (num_samples * num_models)
+        num_reference_models (Optional[int]): Number of reference models used for the attack. Defaults to half reference models if None.
+
+    Returns:
+        np.ndarray: Average softmax value for each sample over OUT reference models.
+    """
+    non_members = ~ref_memberships
+    out_signals = ref_signals * non_members
+    # Sort the signals such that only the non-zero signals (out signals) for each sample are kept
+    if num_reference_models is None:
+        num_reference_models = ref_signals.shape[1]
+    out_signals = -np.sort(-out_signals, axis=1)[:, :num_reference_models]
+    return out_signals
+
+def tune_offline_a(
+    target_model_idx: int,
+    all_signals: np.ndarray,
+    all_memberships: np.ndarray,
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    logger: Any,
+) -> float:
+    """
+    Fine-tune coefficient offline_a used in RMIA.
+
+    Args:
+        target_model_idx (int): Index of the target model.
+        all_signals (np.ndarray): Softmax value of all samples in two models (target and reference).
+        all_memberships (np.ndarray): Membership matrix for all models.
+        ref_signals (np.ndarray): Softmax value of all samples in all reference models.
+        ref_memberships (np.ndarray): Membership matrix for all reference models.
+        logger (Any): Logger object for the current run.
+
+    Returns:
+        float: Optimized offline_a obtained by attacking a paired model with the help of the reference models.
+    """
+    paired_model_idx = (
+        target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+    )
+    logger.info(f"Fine-tuning offline_a using paired model {paired_model_idx}")
+    paired_memberships = all_memberships[:, paired_model_idx]
+    offline_a = 0.0
+    max_auc = 0
+    for test_a in np.arange(0, 1.1, 0.1):
+        paired_signals = all_signals[:, paired_model_idx]
+
+        # launch RMIA using one pair of reference models on the paired model
+        mia_scores = run_rmia(paired_signals, ref_signals, ref_memberships, test_a, 1)
+
+        fpr_list, tpr_list, _ = roc_curve(
+            paired_memberships.ravel(), mia_scores.ravel()
+        )
+        roc_auc = auc(fpr_list, tpr_list)
+        if roc_auc > max_auc:
+            max_auc = roc_auc
+            offline_a = test_a
+            mia_scores_array = mia_scores.ravel().copy()
+            membership_array = paired_memberships.ravel().copy()
+        logger.info(f"offline_a={test_a:.2f}: AUC {roc_auc:.4f}")
+    return offline_a, mia_scores_array, membership_array
+
+def run_rmia(
+    target_signals: np.ndarray,
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    offline_a: float,
+    num_reference_models: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Attack a target model using the RMIA attack with the help of offline reference models.
+
+    Args:
+        target_signals (np.ndarray): Softmax value of all samples in the target model.
+        ref_signals (np.ndarray): Softmax value of all samples in the reference models.
+        ref_memberships (np.ndarray): Membership matrix for all reference models.
+        offline_a (float): Coefficient offline_a is used to approximate p(x) using P_out in the offline setting.
+        num_reference_models (Optional[int]): Number of reference models used for the attack. Defaults to half reference models if None.
+    
+    Returns:
+        np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+    """
+    if num_reference_models is None:
+        num_reference_models = ref_signals.shape[1]//2
+    out_signals = get_out_ref_signals(ref_signals, ref_memberships, num_reference_models)
+    mean_out_x = np.mean(out_signals, axis=1)
+    mean_x = (1 + offline_a) / 2 * mean_out_x + (1 - offline_a) / 2
+    prob_ratio_x = target_signals.ravel() / mean_x
+
+    return prob_ratio_x

--- a/run_duci.py
+++ b/run_duci.py
@@ -1,0 +1,144 @@
+"""This file is the main entry point for running the privacy auditing tool."""
+
+import argparse
+import math
+import time
+
+import torch
+import yaml
+import numpy as np
+
+from audit import get_average_audit_results, audit_models, sample_auditing_dataset
+from get_signals import get_model_signals
+from models.utils import load_models, train_models, split_dataset_for_training
+from util import (
+    check_configs,
+    setup_log,
+    initialize_seeds,
+    create_directories,
+    load_dataset,
+)
+from module_duci import DUCI
+
+# Enable benchmark mode in cudnn to improve performance when input sizes are consistent
+torch.backends.cudnn.benchmark = True
+
+
+def main():
+    print(20 * "-")
+    print("Run Dataset Usage Cardinality Inference!")
+    print(20 * "-")
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="Run DUCI using Privacy Meter.")
+    parser.add_argument(
+        "--cf",
+        type=str,
+        default="configs/cifar10.yaml",
+        help="Path to the configuration YAML file.",
+    )
+    args = parser.parse_args()
+
+    # Load configuration file
+    with open(args.cf, "rb") as f:
+        configs = yaml.load(f, Loader=yaml.Loader)
+
+    # Validate configurations
+    check_configs(configs)
+
+    # Initialize seeds for reproducibility
+    initialize_seeds(configs["run"]["random_seed"])
+
+    # Create necessary directories
+    log_dir = configs["run"]["log_dir"]
+    directories = {
+        "log_dir": log_dir,
+        "report_dir": f"{log_dir}/report",
+        "signal_dir": f"{log_dir}/signals",
+        "data_dir": configs["data"]["data_dir"],
+    }
+    create_directories(directories)
+
+    # Set up logger
+    logger = setup_log(
+        directories["report_dir"], "time_analysis", configs["run"]["time_log"]
+    )
+
+    start_time = time.time()
+
+    # Load the dataset
+    baseline_time = time.time()
+    dataset = load_dataset(configs, directories["data_dir"], logger)
+    logger.info("Loading dataset took %0.5f seconds", time.time() - baseline_time)
+
+    # Define experiment parameters
+    num_experiments = configs["run"]["num_experiments"]
+    num_reference_models = configs["audit"]["num_ref_models"]
+    num_model_pairs = max(math.ceil(num_experiments / 2.0), num_reference_models + 1)
+
+    # Load or train models
+    baseline_time = time.time()
+    models_list, memberships = load_models(
+        log_dir, dataset, num_model_pairs * 2, configs, logger
+    )
+    if models_list is None:
+        # Split dataset for training two models per pair
+        data_splits, memberships = split_dataset_for_training(
+            len(dataset), num_model_pairs
+        )
+        models_list = train_models(
+            log_dir, dataset, data_splits, memberships, configs, logger
+        )
+    logger.info(
+        "Model loading/training took %0.1f seconds", time.time() - baseline_time
+    )
+
+    auditing_dataset, auditing_membership = sample_auditing_dataset(
+        configs, dataset, logger, memberships
+    )
+
+    # Generate signals (softmax outputs) for all models
+    baseline_time = time.time()
+    signals = get_model_signals(models_list, auditing_dataset, configs, logger) # num_models * num_samples
+    logger.info("Preparing signals took %0.5f seconds", time.time() - baseline_time)
+
+    # Perform DUCI
+    baseline_time = time.time()
+    target_model_indices = list(range(num_experiments))
+
+    logger.info(f"Initiate DUCI for target models: {target_model_indices}")
+    DUCI_instance = DUCI(num_reference_models)
+
+    logger.info("Collecting membership prediction for each sample in the target dataset on target models and reference models.")
+    mia_score_list, membership_list, offline_a = DUCI_instance.get_ind_signals(
+        target_model_indices,
+        signals,
+        auditing_membership,
+        num_reference_models,
+        logger,
+        configs,
+    )
+
+    logger.info("Predicting the proportion of dataset usage on target models.") #TODO: remove the baseline
+    _, duci = DUCI_instance.pred_proportion(
+        target_model_indices, 
+        mia_score_list, 
+        membership_list, 
+        offline_a
+    )
+
+    if len(target_model_indices) > 1:
+        logger.info(
+            "DUCI %0.1f seconds", time.time() - baseline_time
+        )
+
+    # Get average prediction errors across all experiments
+    if len(target_model_indices) > 1:
+        logger.info(f"Average prediction errors: agg-MIA baseline {np.mean(agg_mia_baseline)} | DUCI: {np.mean(duci)}")
+
+
+    logger.info("Total runtime: %0.5f seconds", time.time() - start_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_duci.py
+++ b/run_duci.py
@@ -106,7 +106,7 @@ def main():
 
     ######################################  Perform DUCI ######################################
     baseline_time = time.time()
-    target_model_indices = list(range(num_experiments))
+    target_model_indices = list(range(2*(num_experiments+1))) # Each run uses one model as target model
 
     ############################  Input your own reference model indices ############################
     #Sample: construct reference models
@@ -125,7 +125,13 @@ def main():
 
 
     logger.info(f"Initiate DUCI for target models: {target_model_indices}")
-    DUCI_instance = DUCI(logger)
+    args = {
+        "attack": "RMIA",
+        "dataset": configs["data"]["dataset"], # TODO: have DUCI config
+        "model": configs["train"]["model_name"],
+        "offline_a": 0.3
+    }
+    DUCI_instance = DUCI(logger, args)
 
     logger.info("Collecting membership prediction for each sample in the target dataset on target models and reference models.")
     logger.info("Predicting the proportion of dataset usage on target models.")


### PR DESCRIPTION
Original MIA attack can be launched by `MIA.run_mia` using `args["attack"]` to control the attack type (default to be RMIA)

Example:

```
# Each run uses one model as target model and selects reference models from the remaining models
target_model_indices = list(range(2*(num_experiments+1)))
reference_model_indices_all = []
for target_model_idx in target_model_indices:
    paired_model_idx = (
        target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
    )
    # Select reference models from non-target and non-paired model indices
    ref_indices = [
        I
        for i in range(signals.shape[1])
        if i != target_model_idx and i != paired_model_idx
    ][: 2 * num_reference_models]
    reference_model_indices_all.append(np.array(ref_indices))

args = {
        "attack": "RMIA",
        "dataset": configs["data"]["dataset"],
        "model": configs["train"]["model_name"],
        "offline_a": 0.3
    }

# Initialize the MIA instance
MIA_instance = MIA(logger)
mia_scores, target_memberships = MIA_instance.run_mia(
      all_signals, 
      all_memberships, 
      target_model_idx, 
      reference_model_indices, 
      logger, 
      args,
      reuse_offline_a=False
  )
```